### PR TITLE
Python implementation of the baseline code

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+autopep8 = "*"
+pytest = "*"
+beautifulsoup4 = "*"
+dataclasses-json = "*"
+ujson = "*"
+dacite = "*"
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,204 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b20f3146c6f63b615bb6022df9355ad16ffdf3b3033f7a9676d68b73668dea88"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "autopep8": {
+            "hashes": [
+                "sha256:276ced7e9e3cb22e5d7c14748384a5cf5d9002257c0ed50c0e075b68011bb6d0",
+                "sha256:aa213493c30dcdac99537249ee65b24af0b2c29f2e83cd8b3f68760441ed0db9"
+            ],
+            "index": "pypi",
+            "version": "==1.5.7"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35",
+                "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25",
+                "sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666"
+            ],
+            "index": "pypi",
+            "version": "==4.9.3"
+        },
+        "dacite": {
+            "hashes": [
+                "sha256:4331535f7aabb505c732fa4c3c094313fc0a1d5ea19907bf4726a7819a68b93f",
+                "sha256:d48125ed0a0352d3de9f493bf980038088f45f3f9d7498f090b50a847daaa6df"
+            ],
+            "index": "pypi",
+            "version": "==1.6.0"
+        },
+        "dataclasses-json": {
+            "hashes": [
+                "sha256:0b25143f621d0122a2de123c156a5f6909c28d0fdd8c2e1ca2a6e4042130ad32",
+                "sha256:6c3976816fd3cdd8db3be2b516b64fc083acd46ac22c680d3dc24cb1d6ae3367"
+            ],
+            "index": "pypi",
+            "version": "==0.5.4"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "marshmallow": {
+            "hashes": [
+                "sha256:8050475b70470cc58f4441ee92375db611792ba39ca1ad41d39cad193ea9e040",
+                "sha256:b45cde981d1835145257b4a3c5cb7b80786dcf5f50dd2990749a50c16cb48e01"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.12.1"
+        },
+        "marshmallow-enum": {
+            "hashes": [
+                "sha256:38e697e11f45a8e64b4a1e664000897c659b60aa57bfa18d44e226a9920b6e58",
+                "sha256:57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072"
+            ],
+            "version": "==1.5.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
+                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.7.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "index": "pypi",
+            "version": "==6.2.4"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
+                "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==2.2.1"
+        },
+        "stringcase": {
+            "hashes": [
+                "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"
+            ],
+            "version": "==1.2.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
+                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
+                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+            ],
+            "version": "==3.10.0.0"
+        },
+        "typing-inspect": {
+            "hashes": [
+                "sha256:047d4097d9b17f46531bf6f014356111a1b6fb821a24fe7ac909853ca2a782aa",
+                "sha256:3cd7d4563e997719a710a3bfe7ffb544c6b72069b6812a02e9b414a8fa3aaa6b",
+                "sha256:b1f56c0783ef0f25fb064a01be6e5407e54cf4a4bf4f3ba3fe51e0bd6dcea9e5"
+            ],
+            "version": "==0.7.1"
+        },
+        "ujson": {
+            "hashes": [
+                "sha256:0190d26c0e990c17ad072ec8593647218fe1c675d11089cd3d1440175b568967",
+                "sha256:0ea07fe57f9157118ca689e7f6db72759395b99121c0ff038d2e38649c626fb1",
+                "sha256:30962467c36ff6de6161d784cd2a6aac1097f0128b522d6e9291678e34fb2b47",
+                "sha256:4d6d061563470cac889c0a9fd367013a5dbd8efc36ad01ab3e67a57e56cad720",
+                "sha256:5e1636b94c7f1f59a8ead4c8a7bab1b12cc52d4c21ababa295ffec56b445fd2a",
+                "sha256:7333e8bc45ea28c74ae26157eacaed5e5629dbada32e0103c23eb368f93af108",
+                "sha256:84b1dca0d53b0a8d58835f72ea2894e4d6cf7a5dd8f520ab4cbd698c81e49737",
+                "sha256:91396a585ba51f84dc71c8da60cdc86de6b60ba0272c389b6482020a1fac9394",
+                "sha256:a214ba5a21dad71a43c0f5aef917cd56a2d70bc974d845be211c66b6742a471c",
+                "sha256:aad6d92f4d71e37ea70e966500f1951ecd065edca3a70d3861b37b176dd6702c",
+                "sha256:b3a6dcc660220539aa718bcc9dbd6dedf2a01d19c875d1033f028f212e36d6bb",
+                "sha256:b5c70704962cf93ec6ea3271a47d952b75ae1980d6c56b8496cec2a722075939",
+                "sha256:c615a9e9e378a7383b756b7e7a73c38b22aeb8967a8bfbffd4741f7ffd043c4d",
+                "sha256:d3a87888c40b5bfcf69b4030427cd666893e826e82cc8608d1ba8b4b5e04ea99",
+                "sha256:e2cadeb0ddc98e3963bea266cc5b884e5d77d73adf807f0bda9eca64d1c509d5",
+                "sha256:e390df0dcc7897ffb98e17eae1f4c442c39c91814c298ad84d935a3c5c7a32fa",
+                "sha256:e6e90330670c78e727d6637bb5a215d3e093d8e3570d439fd4922942f88da361",
+                "sha256:eb6b25a7670c7537a5998e695fa62ff13c7f9c33faf82927adf4daa460d5f62e",
+                "sha256:f273a875c0b42c2a019c337631bc1907f6fdfbc84210cc0d1fff0e2019bbfaec",
+                "sha256:f8aded54c2bc554ce20b397f72101737dd61ee7b81c771684a7dd7805e6cca0c",
+                "sha256:fc51e545d65689c398161f07fd405104956ec27f22453de85898fa088b2cd4bb"
+            ],
+            "index": "pypi",
+            "version": "==4.0.2"
+        }
+    }
+}

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,3 @@
+data/*
+output/*
+tmp/*

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,61 @@
+# Wikilinks JP (Python version)
+
+This is the Python version of the Go language implementation published by the official.
+
+## Usage
+
+Clone this repository first.
+```
+$ git clone https://github.com/usami/wikilinks-jp.git
+```
+
+Create a virtual environment with pipenv and install the necessary libraries.
+
+```
+$ cd wikilinks-jp/python
+$ pipenv install --dev (or pipenv sync --dev)
+```
+
+Then running `./do_python.sh link-sample` downloads the sample data, builds the linker and runs the linker against the sample data.
+
+```
+$ ./do_python.sh link-sample
+```
+
+Example outputs can be found under `output/sample`.
+
+```
+$ ls output/sample/
+airport.json  city.json  company.json  compound.json  person.json
+```
+
+The linker can be used as a CLI tool.
+
+```
+Usage: python main.py [category] [annotation-file] [html-dir] [title-pageid-file] [output-file]
+```
+
+## Test
+
+It is possible to test with pytest.
+
+```
+cd python
+pytest -v tests/
+```
+
+# Requirements
+
+### Softwares
+
+The linker and `do_python.sh` script assumes the following commands are installed:
+
+- python 3.8+
+- python libraries (in Pipfile)
+- curl
+- unzip
+- gunzip
+
+### Files
+
+The linker requires Wikipedia title to pageid mapping file. A mapping file is bandled with this repo (`wikilinks-jp/data/jawiki-20190120-title2pageid.json.gz`). You can download the latest version [here](https://drive.google.com/drive/folders/1ncZnWgDPFuoKQyqAVIaDnnx85sjsW5cN?usp=sharing).

--- a/python/README.md
+++ b/python/README.md
@@ -12,13 +12,14 @@ $ git clone https://github.com/usami/wikilinks-jp.git
 Create a virtual environment with pipenv and install the necessary libraries.
 
 ```
-$ cd wikilinks-jp/python
+$ cd wikilinks-jp/
 $ pipenv install --dev (or pipenv sync --dev)
 ```
 
 Then running `./do_python.sh link-sample` downloads the sample data, builds the linker and runs the linker against the sample data.
 
 ```
+$ cd python/
 $ ./do_python.sh link-sample
 ```
 

--- a/python/do_python.sh
+++ b/python/do_python.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+SAMPLE_DATE=210408
+
+help_download_sample="Download SHINRA2021-LinkJP task sample data."
+download-sample() {
+  mkdir -p tmp
+  mkdir -p data
+
+  rm -rf "data/linkjp-sample-${SAMPLE_DATE}"
+
+  local fileid=1rH-0L2E7Cxd8JIhss6AL1RZdPkSJLyJ-
+  local out=tmp/linkjp-sample.zip
+  curl -L -o ${out} "https://drive.google.com/uc?export=download&id=${fileid}"
+  unzip ${out} -d data/
+}
+
+help_link_sample="Run Wikilinks-jp linker for sample data."
+link-sample() {
+  local sample_dir="data/linkjp-sample-${SAMPLE_DATE}"
+  local output_dir=output/sample
+  local title_pageid_json=../data/jawiki-20190120-title2pageid.json
+
+  [ ! -d "${sample_dir}" ] && download-sample
+  [ ! -f "${title_pageid_json}" ] && gunzip --keep ${title_pageid_json}.gz
+
+  rm -rf $output_dir
+  mkdir -p $output_dir
+
+  for cat in airport city company compound person; do
+    local cat_title=${cat^} # bash version > 4
+    local annotation_json=${sample_dir}/ene_annotation/${cat_title}.json
+    local html_dir=${sample_dir}/html/${cat_title}
+    python main.py $cat $annotation_json $html_dir $title_pageid_json $output_dir/$cat.json
+  done
+}
+
+list() {
+  declare -F | awk '{print $3}'
+}
+
+help_help="Print help text, or detailed help for a task."
+help() {
+  local item="${1-}"
+  if [ -n "${item}" ]; then
+    local help_name="help_${item//-/_}"
+    echo "${!help_name-}"
+    return
+  fi
+
+  type -t help-text-intro >/dev/null && help-text-intro
+  for item in $(list); do
+    local help_name="help_${item//-/_}"
+    local text="${!help_name-}"
+    [ -n "$text" ] && printf "%-20s\t%s\n" $item "$(echo "$text" | head -1)"
+  done
+}
+
+case "${1-}" in
+list) list ;;
+"" | "help") help "${2-}" ;;
+*) "$@" ;;
+esac

--- a/python/do_python.sh
+++ b/python/do_python.sh
@@ -16,6 +16,11 @@ download-sample() {
   unzip ${out} -d data/
 }
 
+help_test="Run all tests."
+test() {
+  pytest -v tests/
+}
+
 help_link_sample="Run Wikilinks-jp linker for sample data."
 link-sample() {
   local sample_dir="data/linkjp-sample-${SAMPLE_DATE}"
@@ -29,7 +34,7 @@ link-sample() {
   mkdir -p $output_dir
 
   for cat in airport city company compound person; do
-    local cat_title=${cat^} # bash version > 4
+    local cat_title=${cat^} # bash version >= 4
     local annotation_json=${sample_dir}/ene_annotation/${cat_title}.json
     local html_dir=${sample_dir}/html/${cat_title}
     python main.py $cat $annotation_json $html_dir $title_pageid_json $output_dir/$cat.json

--- a/python/main.py
+++ b/python/main.py
@@ -1,0 +1,38 @@
+import argparse
+from src.linker.linker import Linker
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "category",
+        help="Specify category [Airport City Company Compound Person]"
+    )
+    parser.add_argument(
+        "annotation_file",
+        help="Specify annotation json filepath"
+    )
+    parser.add_argument(
+        "html_dir",
+        help="Specify base directory path that cotains html files"
+    )
+    parser.add_argument(
+        "title_pageid_file",
+        help="Specify title2pageid.json filepath"
+    )
+    parser.add_argument(
+        "output_file",
+        help="Specify output filepath"
+    )
+    args = parser.parse_args()
+
+    l = Linker(args.category)
+    l.load(args.annotation_file, args.html_dir, args.title_pageid_file)
+
+    l.run()
+
+    l.output(args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/linker/linker.py
+++ b/python/src/linker/linker.py
@@ -1,0 +1,167 @@
+import json
+import ujson
+import logging
+import os
+from typing import List, Dict
+from urllib.parse import urlparse, unquote
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag, NavigableString
+from dacite import from_dict
+
+from src.types.annotation import Annotation
+from src.types.page import Page, parse_page_id, load_page_from_html
+from src.types.title_pageid import TitlePageIDWithRedirect
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+    level=logging.INFO,
+)
+
+
+class Linker:
+    def __init__(
+            self, category: str, annotations: List[Annotation] = None,
+            pages: Dict[str, Page] = None, title_to_page_id: Dict[str, int] = None) -> None:
+        self.category: str = category
+        self.annotations: List[Annotation] = [
+        ] if annotations is None else annotations
+        self.pages: Dict[str, Page] = {} if pages is None else pages
+        self.title_to_page_id: Dict[str, int] = {
+        } if title_to_page_id is None else title_to_page_id
+
+    def load(self, a: str, d: str, t: str) -> None:
+        logger.info("linker[%s]: load annotaions", self.category)
+        self.load_annotations(a)
+        logger.info("linker[%s]: load pages", self.category)
+        self.load_pages(d)
+        logger.info("linker[%s]: load title to pageid mappings", self.category)
+        self.load_title_page_ids(t)
+
+    def run(self) -> None:
+        logger.info("linker[%s]: check links", self.category)
+        self.check_links()
+
+    def output(self, filepath: str) -> None:
+        logger.info("linker[%s]: output analyzed results", self.category)
+
+        with open(filepath, mode="w") as f:
+            for an in self.annotations:
+                if an.link_page_id != "":
+                    json_str = an.to_json(ensure_ascii=False)
+                    s = json_str + "\n"
+                    f.write(s)
+
+    def load_annotations(self, filepath: str) -> None:
+        aa: List[Annotation] = []
+        with open(filepath, mode="r") as f:
+            for line in f:
+                d = json.loads(line)
+                an = from_dict(Annotation, d)
+                aa.append(an)
+
+        self.annotations = aa
+
+    def load_pages(self, dirpath: str) -> None:
+        files = list_html_files(dirpath)
+
+        amap: Dict[str, List[int]] = {}
+
+        for an in self.annotations:
+            lines = amap.get(an.page_id, [])
+            lines.append(an.html_offset.start.line_id)
+            amap[an.page_id] = lines
+
+        for f in files:
+            pid = parse_page_id(f)
+            if pid in amap:
+                page = load_page_from_html(f, pid, amap[pid])
+                self.pages[page.page_id] = page
+
+    def load_title_page_ids(self, filepath: str) -> None:
+        base_name = os.path.basename(filepath)
+        dirname = os.path.dirname(filepath)
+        dic_path = os.path.join(dirname, "dic-" + base_name)
+        if os.path.exists(dic_path):
+            logger.info(
+                "exists dictionary file of title to page id. loading dictionary file...")
+            with open(dic_path, mode="r") as f:
+                self.title_to_page_id = json.load(f)
+            return
+
+        logger.info("not exists dictionary file of title to page id.")
+        with open(filepath, mode="r") as f:
+            for i, line in enumerate(f):
+                if i % 10000 == 0:
+                    logger.info("step of loading title page ids: %s", i)
+                d = ujson.loads(line)
+                if "redirect_to" in d:
+                    if d["redirect_to"]["page_id"] is None or d["redirect_to"]["title"] is None:
+                        del d["redirect_to"]
+                        d["is_redirect"] = False
+
+                t = from_dict(TitlePageIDWithRedirect, d)
+                self.title_to_page_id[t.title] = t.resolve()
+
+        with open(dic_path, mode="w") as f:
+            json.dump(self.title_to_page_id, f, indent=2, ensure_ascii=False)
+
+    def check_links(self):
+        for an in self.annotations:
+            p = self.pages[an.page_id]
+            li = an.html_offset.start.line_id
+            soup = BeautifulSoup(p.lines[li], 'html.parser')
+
+            def f(n, offset: int) -> int:
+                if type(n) == Tag:
+                    if n.name == "a":
+                        href = n.attrs["href"]
+                        if is_link_to_entity(href):
+                            if hasattr(n, "children"):
+                                first_child = list(n.children)[0]
+                                if matches_annotation(first_child, an, offset):
+                                    title = extract_title(href)
+                                    if title in self.title_to_page_id:
+                                        page_id = self.title_to_page_id[title]
+                                        an.link_page_id = str(page_id)
+                elif type(n) == NavigableString:
+                    offset += len(n.string)
+
+                if hasattr(n, "children"):
+                    for c in n.children:
+                        offset = f(c, offset)
+
+                return offset
+
+            f(soup, 0)
+
+
+def list_html_files(dirpath: str) -> List[str]:
+    file_list: List[str] = []
+    for cur_dir, dirs, files in os.walk(dirpath):
+        for f in files:
+            _, ext = os.path.splitext(f)
+            if ext == '.html':
+                path = os.path.join(cur_dir, f)
+                file_list.append(path)
+    return file_list
+
+
+def is_link_to_entity(a: str) -> bool:
+    return a.startswith("/index.php/") or a.startswith("/a-sumida/wiki2019_1/index.php/")
+
+
+def extract_title(s: str) -> str:
+    u = urlparse(s)
+    path = u.path
+    parts = path.split("/")
+    title = unquote(parts[len(parts)-1])
+    return title
+
+
+def matches_annotation(n, a: Annotation, offset: int) -> bool:
+    if not type(n) == NavigableString:
+        return False
+    return a.text_offset.start.offset == offset and a.text_offset.text == n.string

--- a/python/src/types/annotation.py
+++ b/python/src/types/annotation.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json
+
+
+@dataclass
+class Offset:
+    line_id: int
+    offset: int
+
+
+@dataclass
+class OffsetPair:
+    start: Offset
+    end: Offset
+    text: str
+
+
+@dataclass_json
+@dataclass
+class Annotation:
+    ENE: str
+    attribute: str
+    html_offset: OffsetPair
+    text_offset: OffsetPair
+    page_id: str
+    title: str
+    link_page_id: str = ""

--- a/python/src/types/page.py
+++ b/python/src/types/page.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+import os
+from typing import Dict, List
+
+
+@dataclass
+class Page:
+    page_id: str
+    lines: Dict[int, str]
+
+
+def parse_page_id(s: str) -> str:
+    base = os.path.basename(s)
+    fe = base.split(".")
+    return fe[0]
+
+
+def load_page_from_html(filepath: str, p: str, line_ids: List[int]) -> Page:
+    with open(filepath, mode="r") as f:
+        raw = f.read()
+
+    whole_lines = raw.split("\n")
+
+    lines = {}
+    for line_id in line_ids:
+        lines[line_id] = whole_lines[line_id]
+
+    return Page(page_id=p, lines=lines)

--- a/python/src/types/title_pageid.py
+++ b/python/src/types/title_pageid.py
@@ -1,0 +1,26 @@
+from abc import ABCMeta
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TitlePageID(metaclass=ABCMeta):
+    page_id: int
+    title: str
+    is_redirect: bool
+
+    def __new__(cls, *args, **kwargs):
+        dataclass(cls)
+        return super().__new__(cls)
+
+
+# dataclassの継承について
+# https://zenn.dev/enven/articles/8b80ff38461b4ff329aa#%E3%83%87%E3%83%BC%E3%82%BF%E3%82%AF%E3%83%A9%E3%82%B9%E3%82%92%E7%B6%99%E6%89%BF%E3%81%99%E3%82%8B
+@dataclass
+class TitlePageIDWithRedirect(TitlePageID):
+    redirect_to: Optional[TitlePageID]
+
+    def resolve(self) -> int:
+        if self.is_redirect:
+            return self.redirect_to.page_id
+        return self.page_id

--- a/python/tests/test_linker.py
+++ b/python/tests/test_linker.py
@@ -1,0 +1,111 @@
+from src.types.annotation import Annotation, Offset, OffsetPair
+from src.linker.linker import Linker, list_html_files, extract_title
+
+
+def test_new_linker():
+    l = Linker("airport")
+
+    assert l.category == "airport"
+
+
+def test_load_annotations():
+    l = Linker("airport")
+
+    assert len(l.annotations) == 0
+    l.load_annotations("../testdata/annotations.json")
+    assert len(l.annotations) == 10
+
+    assert l.annotations[2].html_offset.text == "Pekoa Airfield"
+    assert l.annotations[3].html_offset.text == "ペコア飛行場"
+
+
+def test_load_pages():
+    l = Linker("airport")
+    l.load_annotations("../testdata/annotations.json")
+
+    assert len(l.pages) == 0
+    l.load_pages("../testdata")
+    assert len(l.pages) == 1
+
+    p = l.pages["1017261"]
+    assert p.page_id == "1017261"
+    assert len(p.lines) == 6
+
+
+def test_load_title_page_ids():
+    l = Linker("airport")
+    l.load_title_page_ids("../testdata/title2pageid.json")
+
+    assert len(l.title_to_page_id) == 10
+    assert l.title_to_page_id["!"] == 124376
+
+
+def test_check_links():
+    l = Linker("airport")
+
+    an = Annotation(
+        ENE="1.6.5.3",
+        attribute="国",
+        text_offset=OffsetPair(
+            start=Offset(line_id=63, offset=63),
+            end=Offset(line_id=63, offset=67),
+            text="バヌアツ",
+        ),
+        html_offset=OffsetPair(
+            start=Offset(line_id=63, offset=151),
+            end=Offset(line_id=63, offset=155),
+            text="バヌアツ",
+        ),
+        page_id="1017261",
+        title="サントペコア国際空港",
+    )
+
+    l.annotations.append(an)
+    l.load_pages("../testdata/")
+    l.title_to_page_id["バヌアツ"] = 10
+
+    l.check_links()
+
+    assert l.annotations[0].link_page_id == "10"
+
+    l.load_annotations("../testdata/annotations.json")
+    l.load_pages("../testdata")
+    l.title_to_page_id["エスピリトゥサント島"] = 100
+    l.title_to_page_id["ルーガンビル"] = 1000
+
+    l.check_links()
+
+    expected = [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "10",
+        "10",
+        "100",
+        "1000",
+    ]
+
+    for i, an in enumerate(l.annotations):
+        assert an.link_page_id == expected[i]
+
+
+def test_list_html_files():
+    files = sorted(list_html_files("../testdata"))
+    assert len(files) == 2
+    assert files == sorted(
+        ["../testdata/1017261.html", "../testdata/4189.html"])
+
+
+def test_extract_title():
+    s = "/index.php/%E3%83%90%E3%83%8C%E3%82%A2%E3%83%84"
+
+    title = extract_title(s)
+    assert title == "バヌアツ"
+
+    s = "/a-sumida/wiki2019_1/index.php/1965%E5%B9%B4"
+
+    title = extract_title(s)
+    assert title == "1965年"

--- a/python/tests/types/test_annotation.py
+++ b/python/tests/types/test_annotation.py
@@ -1,0 +1,30 @@
+import json
+from dacite import from_dict
+from src.types.annotation import Annotation
+
+
+def test_annotation():
+    with open("../testdata/annotation_sample.json", mode="r") as f:
+        d = json.load(f)
+
+    a = from_dict(Annotation, d)
+
+    assert a.ENE == "1.6.5.3"
+    assert a.attribute == "別名"
+    assert a.page_id == "1017261"
+    assert a.title == "サントペコア国際空港"
+    assert a.link_page_id == ""
+
+    ho = a.html_offset
+    assert ho.text == "Santo-Pekoa International Airport"
+    assert ho.start.line_id == 63
+    assert ho.start.offset == 39
+    assert ho.end.line_id == 63
+    assert ho.end.offset == 72
+
+    to = a.text_offset
+    assert to.text == "Santo-Pekoa International Airport"
+    assert to.start.line_id == 63
+    assert to.start.offset == 26
+    assert to.end.line_id == 63
+    assert to.end.offset == 59

--- a/python/tests/types/test_page.py
+++ b/python/tests/types/test_page.py
@@ -1,0 +1,9 @@
+from src.types.page import load_page_from_html
+
+
+def test_load_page_from_html():
+    p = load_page_from_html("../testdata/1017261.html",
+                            "1017261", [1, 10, 14, 18])
+
+    assert p.page_id == "1017261"
+    assert len(p.lines) == 4

--- a/python/tests/types/test_title_pageid.py
+++ b/python/tests/types/test_title_pageid.py
@@ -1,0 +1,30 @@
+import json
+from dacite import from_dict
+from typing import List
+from src.types.title_pageid import TitlePageIDWithRedirect
+
+
+def test_title_page_id():
+    with open("../testdata/title2pageid.json", mode="r") as f:
+        json_lines = f.readlines()
+
+    tps: List[TitlePageIDWithRedirect] = []
+    for json_line in json_lines:
+        d = json.loads(json_line)
+        tp = from_dict(TitlePageIDWithRedirect, d)
+        tps.append(tp)
+
+    assert len(tps) == 10
+
+    tp = tps[0]
+    assert tp.page_id == 305230
+    assert tp.title == "!"
+    assert tp.is_redirect
+    assert tp.redirect_to.page_id == 124376
+    assert tp.resolve() == 124376
+
+    tp = tps[2]
+    assert tp.page_id == 617718
+    assert tp.title == "!!!"
+    assert not tp.is_redirect
+    assert tp.resolve() == 617718


### PR DESCRIPTION
I ported the baseline code implemented in the Go language to Python.
I have confirmed that the Python version of the code also gives the same values as the score below.

https://github.com/usami/linkjp_scorer#example-usage
```
$ python linkjp_scorer airport --ignore-link-type path-to-sample-data/link_annotation/Airport.json linkjp_scorer/data/baseline/airport.json
precision  recall  f1-score  attribute
    0.000   0.000     0.000  別名
    0.000   0.000     0.000  旧称
    1.000   0.793     0.885  国
    1.000   0.298     0.459  所在地
    1.000   0.583     0.737  母都市
    1.000   0.464     0.634  近隣空港
    0.929   0.591     0.722  運営者
    1.000   1.000     1.000  名前の謂れ
    0.000   0.000     0.000  名称由来人物の地位職業名
    0.659   0.414     0.509  macro-average
    0.986   0.324     0.488  micro-average
```

If it is possible to merge the codes, I would appreciate it.